### PR TITLE
Fix requirements.txt syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,23 @@
-pip3 install torch==1.10.2+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
-pip3 install torchvision --no-dependencies
-pip3 install Pillow
-pip3 install numpy
-pip3 install tqdm
-pip3 install ruamel.yaml
-pip3 install imageio
-pip3 install opensimplex
-pip3 install gym==0.19.0
-pip3 install pandas
-pip3 install matplotlib
-pip3 install wandb
-pip3 install sklearn
-pip3 install opencv-python
-pip3 install h5py
-pip3 install pycocotools
-pip3 install imageio-ffmpeg
-pip3 install procgen
-pip3 install pfrl
-pip3 install tensorboard --no-dependencies
-pip3 install einops
-pip3 install moviepy
+--extra-index-url https://download.pytorch.org/whl/cu113/
+torch==1.10.2+cu113
+torchvision
+Pillow
+numpy
+tqdm
+ruamel.yaml
+imageio
+opensimplex
+gym==0.19.0
+pandas
+matplotlib
+wandb
+sklearn
+opencv-python
+h5py
+pycocotools
+imageio-ffmpeg
+procgen
+pfrl
+tensorboard
+einops
+moviepy


### PR DESCRIPTION
Existing version of the `requirements.txt` file could not be used by `pip`.

Note that I'm not using `--no-dependencies` option for installing `tensorvision` and `tensorboard` as it would require putting `--install-option="--no-deps"` which leads to wheels being disabled for the entire file (some packets here could not be installed without wheels support). Not sure if this is critical. If so, the installation procedure has to be split into multiple stages/requirements lists.